### PR TITLE
passing state as a url param to the authentication endpoint

### DIFF
--- a/sources/YandexAuthenticationHandler.cs
+++ b/sources/YandexAuthenticationHandler.cs
@@ -26,7 +26,7 @@ namespace fpNode.Owin.YandexMiddleware
         private const string GraphApiEndpoint = "https://login.yandex.ru/info";
 
         private readonly ILogger _logger;
-        private readonly HttpClient _httpClient;        
+        private readonly HttpClient _httpClient;
 
         public YandexAuthenticationHandler(HttpClient httpClient, ILogger logger)
         {
@@ -78,12 +78,12 @@ namespace fpNode.Owin.YandexMiddleware
 
                 string state = Options.StateDataFormat.Protect(properties);
 
-                Options.StoreState = state;
-
                 string authorizationEndpoint =
                     "https://oauth.yandex.ru/authorize" +
                         "?client_id=" + Uri.EscapeDataString(Options.AppId) +
-                        "&response_type=code";
+                        "&response_type=code" +
+                        "&state=" + Uri.EscapeDataString(state);
+
                 Response.Redirect(authorizationEndpoint);
             }
 
@@ -158,6 +158,7 @@ namespace fpNode.Owin.YandexMiddleware
             try
             {
                 string code = "";
+                string state = null;
 
                 IReadableStringCollection query = Request.Query;
                 IList<string> values = query.GetValues("code");
@@ -167,7 +168,13 @@ namespace fpNode.Owin.YandexMiddleware
                     code = values[0];
                 }
 
-                properties = Options.StateDataFormat.Unprotect(Options.StoreState);
+                values = query.GetValues("state");
+                if (values != null && values.Count == 1)
+                {
+                    state = values[0];
+                }
+
+                properties = Options.StateDataFormat.Unprotect(state);
                 if (properties == null)
                 {
                     return null;

--- a/sources/YandexAuthenticationOptions.cs
+++ b/sources/YandexAuthenticationOptions.cs
@@ -99,11 +99,6 @@ namespace fpNode.Owin.YandexMiddleware
         public ISecureDataFormat<AuthenticationProperties> StateDataFormat { get; set; }
 
         /// <summary>
-        /// Gets or sets the site redirect url after login 
-        /// </summary>
-        public string StoreState { get; set; }
-
-        /// <summary>
         /// A list of permissions to request.
         /// Can be something like that "audio,video,pages" and etc.
         /// </summary>


### PR DESCRIPTION
The state param is used in oauth2 not just for redirect urls, it's also
used for CSRF. As mentioned in the spec
https://tools.ietf.org/html/rfc6749#section-10.12.

In certain cases this state is lost if kept in the authentication options,
so in order to prevent this, the value is now passed as a url param.

This is also done by the 'official' google/ms/fb providers in
https://github.com/aspnet/AspNetKatana.